### PR TITLE
chore: add type to register sms template

### DIFF
--- a/sns-notification/request/sms-template.dto.ts
+++ b/sns-notification/request/sms-template.dto.ts
@@ -1,0 +1,19 @@
+import { SnsNotificationProviderEnum } from '../../enums/sns-provider.enum';
+import { MessageType, TemplateType } from '../../types/sms-template.type';
+
+export interface RegisterSmsTemplateRequestDto {
+  providerName: SnsNotificationProviderEnum;
+  templateType: TemplateType;
+  subType: MessageType;
+  name: string;
+  content: string;
+  code: string;
+  metadata?: Record<string, any>;
+}
+
+export interface UpdateStoreTemplateConfigRequestDto {
+  providerName: SnsNotificationProviderEnum;
+  subType: MessageType;
+  templateName: string;
+  templateCode: string;
+}

--- a/types/sms-template.type.ts
+++ b/types/sms-template.type.ts
@@ -1,0 +1,9 @@
+export enum TemplateType {
+  EMAIL = 'EMAIL',
+  MESSAGE = 'MESSAGE',
+}
+
+export enum MessageType {
+  PICK_UP = 'PICK_UP',
+  E_RECEIPT = 'E_RECEIPT',
+}


### PR DESCRIPTION
Add type for 2 end point APIs
1. POST {{baseUrl}}/v1/admins/sns-notifications/templates
2. PUT {{baseUrl}}/v1/admins/stores/1/sns-notifications/templates

@hewison-chris @StanSicPama @sicpama-huy 