### PR TITLE
chore: correct menu okpos data

### DIFF
--- a/pos/okpos/menu.ts
+++ b/pos/okpos/menu.ts
@@ -2,7 +2,6 @@ export interface OkPosMenuData {
   PROD_CD: string;
   PROD_NM: string;
   LCLS_CD: string;
-  LCLS_NM: string;
   MCLS_CD: string;
   SCLS_CD: string;
   SALE_UPRC: string;


### PR DESCRIPTION
The name of large category is not included in the PROD data.